### PR TITLE
데드락 감지 로직 개선

### DIFF
--- a/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetector.java
+++ b/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetector.java
@@ -58,7 +58,7 @@ public class ThreadDeadlockDetector implements DeadlockDetector<ThreadDeadlockEv
 
     private void logDeadlock(long threadId, ThreadDeadlockInfo threadDeadlockInfo, long currentTime) {
         if (threadDeadlockInfo.getLastLoggedTime() == 0) {
-            LOG.info("New Thread deadlock detected. Thread ID: {}", threadId);
+            LOG.debug("New Thread deadlock detected. Thread ID: {}", threadId);
             threadDeadlockInfo.setLastLoggedTime(currentTime);
         }
 

--- a/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetector.java
+++ b/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetector.java
@@ -1,16 +1,25 @@
 package com.github.kgggh.deadlock4j.detector;
 
 import com.github.kgggh.deadlock4j.event.ThreadDeadlockEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class ThreadDeadlockDetector implements DeadlockDetector<ThreadDeadlockEvent> {
+    private static final Logger LOG = LoggerFactory.getLogger(ThreadDeadlockDetector.class);
+
     private final ThreadMXBean threadMXBean;
-    private final Set<Long> detectedDeadlockThreads = new HashSet<>();
+    private final Map<Long, ThreadDeadlockInfo> detectedDeadlockThreads = new ConcurrentHashMap<>();
+
+    private static final long DEADLOCK_WARNING_TIME = (long) 10 * 60 * 1000;
+    private static final long DEADLOCK_LOG_INTERVAL = (long) 60 * 1000;
+    private static final long DEADLOCK_EVENT_SUPPRESSION_INTERVAL = (long) 5 * 60 * 1000;
 
     public ThreadDeadlockDetector() {
         this.threadMXBean = ManagementFactory.getThreadMXBean();
@@ -19,32 +28,74 @@ public class ThreadDeadlockDetector implements DeadlockDetector<ThreadDeadlockEv
     @Override
     public List<ThreadDeadlockEvent> detect() {
         long[] deadlockedThreads = threadMXBean.findDeadlockedThreads();
+        long currentTime = System.currentTimeMillis();
+
         if (deadlockedThreads == null) {
             detectedDeadlockThreads.clear();
-
             return Collections.emptyList();
         }
 
         List<ThreadDeadlockEvent> detectedEvents = new ArrayList<>();
-        for(long threadId : deadlockedThreads) {
-            if (!detectedDeadlockThreads.add(threadId)) {
-                continue;
-            }
+        Set<Long> activeThreadDeadlocks = new HashSet<>();
+
+        for (long threadId : deadlockedThreads) {
+            activeThreadDeadlocks.add(threadId);
+            ThreadDeadlockInfo threadDeadlockInfo =
+                detectedDeadlockThreads.computeIfAbsent(threadId, id -> new ThreadDeadlockInfo(currentTime));
+
+            logDeadlock(threadId, threadDeadlockInfo, currentTime);
 
             ThreadInfo threadInfo = threadMXBean.getThreadInfo(threadId, Integer.MAX_VALUE);
-            if (threadInfo != null) {
-                detectedDeadlockThreads.add(threadId);
-                ThreadDeadlockEvent event = convertToEvent(threadInfo);
-                detectedEvents.add(event);
+            if (threadInfo != null && hasSuppressionExpired(threadDeadlockInfo, currentTime)) {
+                detectedEvents.add(convertToEvent(threadInfo, threadDeadlockInfo.getDetectedTime()));
+                threadDeadlockInfo.setLastEventTime(currentTime);
             }
         }
 
+        removeClearedDeadlocks(activeThreadDeadlocks);
         return detectedEvents;
     }
 
-    private ThreadDeadlockEvent convertToEvent(ThreadInfo threadInfo) {
+    private void logDeadlock(long threadId, ThreadDeadlockInfo threadDeadlockInfo, long currentTime) {
+        if (threadDeadlockInfo.getLastLoggedTime() == 0) {
+            LOG.info("New Thread deadlock detected. Thread ID: {}", threadId);
+            threadDeadlockInfo.setLastLoggedTime(currentTime);
+        }
+
+        if (isTimeToLogWarning(threadDeadlockInfo, currentTime)) {
+            LOG.warn("Deadlock detected for over 10 minutes. Thread ID: {}", threadId);
+            threadDeadlockInfo.setLastLoggedTime(currentTime);
+        }
+    }
+
+    /**
+     * Check it is time to log warning for deadlock that running long time.
+     *
+     * Warning log will write when:
+     * 1. Deadlock is running more than DEADLOCK_WARNING_TIME (10 minutes).
+     * 2. Last warning log was written more than DEADLOCK_LOG_INTERVAL (1 minute).
+     *
+     * This is for prevent too many log and make sure deadlock log is not missing.
+     */
+    private boolean isTimeToLogWarning(ThreadDeadlockInfo threadDeadlockInfo, long currentTime) {
+        if (currentTime - threadDeadlockInfo.getDetectedTime() <= DEADLOCK_WARNING_TIME) {
+            return false;
+        }
+
+        return currentTime - threadDeadlockInfo.getLastLoggedTime() > DEADLOCK_LOG_INTERVAL;
+    }
+
+    private boolean hasSuppressionExpired(ThreadDeadlockInfo threadDeadlockInfo, long currentTime) {
+        return currentTime - threadDeadlockInfo.getLastEventTime() > DEADLOCK_EVENT_SUPPRESSION_INTERVAL;
+    }
+
+    private void removeClearedDeadlocks(Set<Long> activeDeadlocks) {
+        detectedDeadlockThreads.keySet().removeIf(threadId -> !activeDeadlocks.contains(threadId));
+    }
+
+    private ThreadDeadlockEvent convertToEvent(ThreadInfo threadInfo, long detectedTime) {
         return new ThreadDeadlockEvent(
-            System.currentTimeMillis(),
+            detectedTime,
             threadInfo.getThreadName(),
             threadInfo.getThreadId(),
             threadInfo.getThreadState().toString(),
@@ -61,5 +112,41 @@ public class ThreadDeadlockDetector implements DeadlockDetector<ThreadDeadlockEv
         return Arrays.stream(stackTrace)
             .map(StackTraceElement::toString)
             .collect(Collectors.joining("\n"));
+    }
+
+    static class ThreadDeadlockInfo {
+        private long detectedTime;
+        private long lastLoggedTime;
+        private long lastEventTime;
+
+        ThreadDeadlockInfo(long detectedTime) {
+            this.detectedTime = detectedTime;
+            this.lastLoggedTime = 0;
+            this.lastEventTime = 0;
+        }
+
+        public long getDetectedTime() {
+            return detectedTime;
+        }
+
+        public void setDetectedTime(long detectedTime) {
+            this.detectedTime = detectedTime;
+        }
+
+        public long getLastLoggedTime() {
+            return lastLoggedTime;
+        }
+
+        public void setLastLoggedTime(long lastLoggedTime) {
+            this.lastLoggedTime = lastLoggedTime;
+        }
+
+        public long getLastEventTime() {
+            return lastEventTime;
+        }
+
+        public void setLastEventTime(long lastEventTime) {
+            this.lastEventTime = lastEventTime;
+        }
     }
 }

--- a/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/exception/DatabaseDeadlockExceptionChecker.java
+++ b/deadlock4j-core/src/main/java/com/github/kgggh/deadlock4j/exception/DatabaseDeadlockExceptionChecker.java
@@ -52,13 +52,16 @@ public class DatabaseDeadlockExceptionChecker {
         addDeadlockException(SQLTransactionRollbackException.class);
     }
 
-
     public void addDeadlockException(Class<? extends Throwable> exceptionClass) {
         deadlockExceptions.add(exceptionClass);
     }
 
     public boolean isDeadlockException(Throwable e) {
         while (e != null) {
+            if (deadlockExceptions.contains(e.getClass())) {
+                return true;
+            }
+
             if (e instanceof SQLException sqlEx) {
                 String sqlState = sqlEx.getSQLState();
                 if (DeadlockSQLState.isDeadlock(sqlState)) {

--- a/deadlock4j-core/src/test/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetectorTest.java
+++ b/deadlock4j-core/src/test/java/com/github/kgggh/deadlock4j/detector/ThreadDeadlockDetectorTest.java
@@ -1,6 +1,8 @@
 package com.github.kgggh.deadlock4j.detector;
 
 import com.github.kgggh.deadlock4j.event.ThreadDeadlockEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,20 +12,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ThreadDeadlockDetectorTest {
 
+    private final ThreadDeadlockDetector detector = new ThreadDeadlockDetector();
+    private Thread thread1;
+    private Thread thread2;
     private final Object lock1 = new Object();
     private final Object lock2 = new Object();
 
-    @Test
-    void testDeadlockDetection() throws InterruptedException {
-        //given
-        CountDownLatch latch = new CountDownLatch(1);
-        ThreadDeadlockDetector detector = new ThreadDeadlockDetector();
+    @BeforeEach
+    void clearPrevDeadlocks() {
+        detector.detect();
+    }
 
-        Thread thread1 = new Thread(() -> {
+    @AfterEach
+    void resetDeadlockThread() throws InterruptedException {
+        releaseDeadlocks();
+        if (thread1 != null && thread1.isAlive()) thread1.join(200);
+        if (thread2 != null && thread2.isAlive()) thread2.join(200);
+    }
+
+    @Test
+    void test_deadlock_detection() throws InterruptedException {
+        // given
+        CountDownLatch latch = new CountDownLatch(1);
+
+        thread1 = new Thread(() -> {
             synchronized (lock1) {
                 try {
                     latch.countDown();
-
                     Thread.sleep(1000);
                     synchronized (lock2) {
                         System.out.println("Thread1 acquired lock2");
@@ -34,11 +49,10 @@ class ThreadDeadlockDetectorTest {
             }
         });
 
-        Thread thread2 = new Thread(() -> {
+        thread2 = new Thread(() -> {
             synchronized (lock2) {
                 try {
                     latch.await();
-
                     Thread.sleep(1000);
                     synchronized (lock1) {
                         System.out.println("Thread2 acquired lock1");
@@ -51,21 +65,73 @@ class ThreadDeadlockDetectorTest {
 
         thread1.start();
         thread2.start();
+        Thread.sleep(2000);
 
-        Thread.sleep(3000);
-
-        //when
+        // when
         List<ThreadDeadlockEvent> detectedEvents = detector.detect();
 
-        //then
+        // then
         assertThat(detectedEvents).hasSize(2);
-
         assertThat(detectedEvents)
             .extracting(ThreadDeadlockEvent::getThreadName)
             .contains(thread1.getName(), thread2.getName());
-
         assertThat(detectedEvents)
             .extracting(ThreadDeadlockEvent::getThreadState)
             .containsAnyOf("BLOCKED", "WAITING");
+    }
+
+    @Test
+    void test_deadlock_logging_and_event_suppression() throws InterruptedException {
+        // given
+        CountDownLatch latch = new CountDownLatch(1);
+
+        thread1 = new Thread(() -> {
+            synchronized (lock1) {
+                try {
+                    latch.countDown();
+                    Thread.sleep(1000);
+                    synchronized (lock2) {
+                        System.out.println("Thread1 acquired lock2");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        thread2 = new Thread(() -> {
+            synchronized (lock2) {
+                try {
+                    latch.await();
+                    Thread.sleep(1000);
+                    synchronized (lock1) {
+                        System.out.println("Thread2 acquired lock1");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        Thread.sleep(2000);
+
+        // when
+        List<ThreadDeadlockEvent> detectedEvents1 = detector.detect();
+        assertThat(detectedEvents1).isNotEmpty();
+
+        List<ThreadDeadlockEvent> detectedEvents2 = detector.detect();
+        assertThat(detectedEvents2).isEmpty();
+    }
+
+    private void releaseDeadlocks() {
+        new Thread(() -> {
+            synchronized (lock1) {
+                synchronized (lock2) {
+                    System.out.println("Deadlock released~~~~~~~~~~~~");
+                }
+            }
+        }).start();
     }
 }

--- a/deadlock4j-spring-boot-autoconfigure/src/main/java/com/github/kgggh/deadlock4j/spring/boot/autoconfigure/Deadlock4jProperties.java
+++ b/deadlock4j-spring-boot-autoconfigure/src/main/java/com/github/kgggh/deadlock4j/spring/boot/autoconfigure/Deadlock4jProperties.java
@@ -4,8 +4,6 @@ import com.github.kgggh.deadlock4j.config.Deadlock4jConfig;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.List;
-
 @Data
 @ConfigurationProperties(prefix = "deadlock4j")
 public class Deadlock4jProperties {
@@ -17,5 +15,4 @@ public class Deadlock4jProperties {
     private int monitorInterval = 1000;
     private int heartbeatInterval = 30000;
     private Deadlock4jConfig.TransportType transportType = Deadlock4jConfig.TransportType.NONE;
-    private List<String> detectDatabaseExceptionClasses;
 }


### PR DESCRIPTION
- detectedDeadlockThreads Set -> Map 변경하여 스레드별 추가 정보 추적
- 데드락 감지 시 ThreadDeadlockInfo 객체를 활용하여 스레드 상태 관리
- 데드락 발생 후 일정 시간 이상 지속될 경우 경고 로그 출력
- 이벤트 억제 로직 추가: 일정 시간 이상 감지된 스레드에 대해서만 이벤트 발송
- 로깅 및 이벤트 처리 주기 조절